### PR TITLE
Add github webhook app

### DIFF
--- a/releasekit/urls.py
+++ b/releasekit/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.conf.urls import include, url
 from django.contrib import admin
 
-
 urlpatterns = [
+    url(r'^webhook', include('webhook.urls')),
     url(r'^admin/', admin.site.urls),
 ]

--- a/webhook/apps.py
+++ b/webhook/apps.py
@@ -1,0 +1,7 @@
+from __future__ import unicode_literals
+
+from django.apps import AppConfig
+
+
+class WebhookConfig(AppConfig):
+    name = 'webhook'

--- a/webhook/tests.py
+++ b/webhook/tests.py
@@ -1,0 +1,17 @@
+from django.test import TestCase, Client, override_settings
+
+@override_settings(ROOT_URLCONF='webhook.urls')
+class WebhookTestCase(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_webhook_response(self):
+        """Webhook returns correct response"""
+        response = self.client.post('/',
+                {'foo': 'bar'},
+                HTTP_X_GITHUB_EVENT='some event',
+                )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['event'], 'some event')

--- a/webhook/urls.py
+++ b/webhook/urls.py
@@ -1,0 +1,6 @@
+from django.conf.urls import url
+from . import views
+
+urlpatterns = [
+    url(r'^/?$', views.webhook, name='webhook'),
+]

--- a/webhook/views.py
+++ b/webhook/views.py
@@ -1,0 +1,8 @@
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+
+@csrf_exempt
+def webhook(request):
+    return JsonResponse({
+        'event': request.META['HTTP_X_GITHUB_EVENT'],
+    })


### PR DESCRIPTION
From what I can tell, Django suggests separating a web project into separate app packages. Since the webhook is pretty self-contained, I figured it makes sense to separate it. This will make it easier to split out later if we need it in a different project.

Feel free to critique my style. I'm still not super-clear on the right code style to use.
